### PR TITLE
No prefixes

### DIFF
--- a/Shapes/boundedThermalTransmittance_existence.ttl
+++ b/Shapes/boundedThermalTransmittance_existence.ttl
@@ -33,10 +33,10 @@ beo:WindowShape
         sh:select """
             SELECT $this ?s 
             WHERE {
-                $this rdf:type beo:Window.
-                ?s props:thermalTransmittance ?o1.
-                ?o1 seas:evaluation ?o2.
-                ?o2 schema:value ?val.
+                $this a <https://pi.pauwel.be/voc/buildingelement#Window> .
+                ?s <http://lbd.arch.rwth-aachen.de/props#thermalTransmittance> ?o1 .
+                ?o1 <https://w3id.org/seas/evaluation> ?o2 .
+                ?o2 <http://schema.org/value> ?val .
             }
             """;
     ].


### PR DESCRIPTION
It appears the SPARQL query doesn't work in the Official shacl implementation. It's exactly the same as this user runs into:
https://github.com/TopQuadrant/shacl/issues/47
Apparently the sh:prefixes shouldn't be just vanilla RDF namespaces but contain some sort of specific SHACL annotations.
I didn't look into this extensively. But here's a PR with fully qualified names.